### PR TITLE
Fix compile errors

### DIFF
--- a/src/algebrasHJ.h
+++ b/src/algebrasHJ.h
@@ -25,8 +25,9 @@
 #ifndef _algebras_h_
 #define _algebras_h_
 
-#include <math.h>
+#include <cmath>
 #include <iostream>
+#include <limits>
 
 using namespace std;
 


### PR DESCRIPTION
On gcc 5.5, building fails with this error:

```
In file included from alignerHJ.h:28:0,
                 from mybandingHJ.h:21,
                 from BayesCAT.C:23:
algebrasHJ.h: In function 'void DoubleNormalise(double&, int&)':
algebrasHJ.h:144:11: error: 'numeric_limits' is not a member of 'std'
   if (f < std::numeric_limits<double>::min()) {
           ^
```

http://en.cppreference.com/w/cpp/types/numeric_limits suggests that this class is located in the `<limits>` include. 

Builds also fail with this error:

```
algebrasHJ.h: In member function 'double BFloat::Value() const':
algebrasHJ.h:65:14: error: 'abs' was not declared in this scope
     if (abs(e) < cBFloatDoubleConvTableSize/2) {
              ^
```

Only `<cmath>` declares the math functions like `abs` in the `std` namespace.